### PR TITLE
Update Power Select

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,13 +34,11 @@
     "ember-cli-release": "0.2.8",
     "ember-cli-sri": "^2.0.0",
     "ember-cli-uglify": "^1.2.0",
-    "ember-data": "^2.3.0",
     "ember-disable-prototype-extensions": "^1.0.0",
     "ember-disable-proxy-controllers": "^1.0.1",
     "ember-export-application-global": "^1.0.4",
     "ember-pagefront": "0.10.10",
     "ember-resolver": "^2.0.3",
-    "ember-sortable": "1.6.3",
     "ember-try": "~0.0.8"
   },
   "keywords": [
@@ -54,7 +52,7 @@
   "dependencies": {
     "ember-cli-babel": "^5.1.5",
     "ember-cli-htmlbars": "^1.0.1",
-    "ember-power-select": "^0.8.0-beta.9",
+    "ember-power-select": "^0.9.0-beta.1",
     "ember-sortable": "^1.6.3"
   },
   "ember-addon": {


### PR DESCRIPTION
Fixes #1

Also removes duplicate ember-sortable deps, and the unnecessary ember-data dep.

Looks like it works fine.
